### PR TITLE
Fix typos and reformat documentation

### DIFF
--- a/deep_slide/convolutional_mlp.py
+++ b/deep_slide/convolutional_mlp.py
@@ -7,12 +7,12 @@ paper's MNIST results.
 
 This implementation simplifies the model in the following ways:
 
- - LeNetConvPool doesn't implement location-specific gain and bias parameters
+ - LeNetConvPool doesn't implement location-specific gain and bias parameters.
  - LeNetConvPool doesn't implement pooling by average, it implements pooling
    by max.
  - Digit classification is implemented with a logistic regression rather than
-   an RBF network
- - LeNet5 was not fully-connected convolutions at second layer
+   an RBF network.
+ - LeNet5 was not fully-connected convolutions at second layer.
 
 References:
  - Y. LeCun, L. Bottou, Y. Bengio and P. Haffner:
@@ -28,7 +28,7 @@ To run:
    
 Result: 
    Best validation error of 6.818182 % obtained at iteration 4332, with test error 8.636364 %
-   The code for file convolutional_mlp81.py ran for 18.66m
+   The code for file convolutional_mlp.py ran for 18.66m
 
 """
 
@@ -274,7 +274,7 @@ def evaluate_lenet5(learning_rate=0.095, n_epochs=2000,
                                    # considered significant
     validation_frequency = min(n_train_batches, patience / 2)
                                   # go through this many
-                                  # minibatche before checking the network
+                                  # minibatches before checking the network
                                   # on the validation set; in this case we
                                   # check every epoch
 

--- a/deep_slide/logistic_sgd.py
+++ b/deep_slide/logistic_sgd.py
@@ -279,7 +279,7 @@ def load_data():
         # we need them as ints (we use labels as index, and if they are
         # floats it doesn't make sense) therefore instead of returning
         # ``shared_y`` we will have to cast it to int. This little hack
-        # lets ous get around this issue
+        # lets us get around this issue
         return shared_x, T.cast(shared_y, 'int32')
 
     test_set_x, test_set_y = shared_dataset(test_set)
@@ -339,7 +339,7 @@ def sgd_optimization_mnist(learning_rate=0.159, n_epochs=2000,
 
     # construct the logistic regression class
     # Each MNIST image has size 28*28
-    #classifier = LogisticRegression(input=x, n_in=28 * 28, n_out=10)
+    # classifier = LogisticRegression(input=x, n_in=28 * 28, n_out=10)
     classifier = LogisticRegression(input=x, n_in=50 * 50, n_out=8)
     
     # the cost we minimize during training is the negative log likelihood of
@@ -409,7 +409,7 @@ def sgd_optimization_mnist(learning_rate=0.159, n_epochs=2000,
                                   # considered significant
     validation_frequency = min(n_train_batches, patience / 2)
                                   # go through this many
-                                  # minibatche before checking the network
+                                  # minibatches before checking the network
                                   # on the validation set; in this case we
                                   # check every epoch
 

--- a/doc/contract.md
+++ b/doc/contract.md
@@ -1,4 +1,5 @@
 Description:
+============
 Our goal is to develop a web-based interface for an active-learning machine learning system. The idea of the active 
 learning system is to present users with a series of examples and ask them to label these examples by their class. 
 This information is used in the background to train a classifier that is refined through iterations of feedback, 
@@ -12,7 +13,7 @@ In the main view, users will be able to create a new classifier and assign it a 
 and assign colors to the classes. They will also be able to export the training data table and see a list of previously 
 trained classifiers.
 
-In the slide view users can interact with the data in the whole-slide format. They can click on cells to add them to 
+In the slide view, users can interact with the data in the whole-slide format. They can click on cells to add them to 
 the training set (for initialization) and view the results of the currently trained classifier by color coding of the 
 boundaries.
 
@@ -22,44 +23,47 @@ click on this grid to correct errors (highlighting misclassifications as red) an
 are displayed.
 
 Roles & Responsibilities:
+==========================
 The software developer will only be responsible for the user interface elements. All data and databases that populate these elements will be provided by Dr. Cooper’s research lab. Emory will be responsible for establishing the slide viewer and boundary display capability (already complete), the database containing boundary values, training set databases, all machine learning and any information that populates the webpage.
 Project code will be stored in a repository accessible to all members (GitHub).
 
 Budget & Timeline:
+==================
 The project is broken up into two phases: the prototyping phase that will establish basic and essential functions and 
 the cleanup phase that will refine the appearance of the prototype and add additional non-essential functions.
 
-Phase I – Prototype & Proof of Concept
-	Main view:
-    *Naming classifier and establishing classes for a new classifier
-			**Assigning colors to classes
-	  *Deleting an existing classifier from the system	
-	  *Exporting training data table to text
-	Viewer mode:
-		*Select examples to initialize classifier
-      **Pull-down to select from classes
-      **Recording clicks and inserting cell and class info into table
-		*Color coding boundaries by class
-      **Cells boundaries are displayed as an SVG – pull cell classes from machine learning database and set their SVG color code according to class
-	Grid view:
-    *Initial grid layout – hardcoded layout (# rows/columns), form IIP queries to pull image data into grid
-		*Clicking and color highlighting for review
-    *Button to initiate training
-		*Basic feedback on accuracy – table in margin
-      *Iteration number
-      *Items in each class
-      *Accuracy
+### Phase I – Prototype & Proof of Concept
 
-Phase II  - Cleanup and Add Functionality
-	Improve overall appearance – add header graphics and cleanup layout
-  Main view:
-		*Selecting datasets
-		*Parameters for machine learning 
-			*Drop down to select classifier type	
-			*Text boxes to capture algorithmic parameters - customized by learning algorithm selection
-	Viewer:
-		*Display “information” hover/click data for cells (certainty measure – a single scalar)
-	Grid view:
-    *Deep linking of training samples – double click on cell in grid sends you to that example on slide and highlights the example
-    *Visualization – line plot of accuracy vs. # samples, histogram of uncertainty measures
-    *Adjustable grid dimensions
+#### Main view:
+* Naming classifier and establishing classes for a new classifier
+	* Assigning colors to classes
+* Deleting an existing classifier from the system	
+* Exporting training data table to text
+#### Viewer mode:
+* Select examples to initialize classifier
+	* Pull-down to select from classes
+	* Recording clicks and inserting cell and class info into table
+* Color coding boundaries by class
+	* Cells boundaries are displayed as an SVG – pull cell classes from machine learning database and set their SVG color code according to class
+#### Grid view:
+* Initial grid layout – hardcoded layout (# rows/columns), form IIP queries to pull image data into grid
+		* Clicking and color highlighting for review
+* Button to initiate training
+	* Basic feedback on accuracy – table in margin
+      * Iteration number
+      * Items in each class
+      * Accuracy
+
+### Phase II  - Cleanup and Add Functionality
+Improve overall appearance – add header graphics and cleanup layout
+#### Main view:
+* Selecting datasets
+* Parameters for machine learning 
+	* Drop down to select classifier type	
+	* Text boxes to capture algorithmic parameters - customized by learning algorithm selection
+#### Viewer mode:
+* Display “information” hover/click data for cells (certainty measure – a single scalar)
+#### Grid view:
+* Deep linking of training samples – double click on cell in grid sends you to that example on slide and highlights the example
+* Visualization – line plot of accuracy vs. # samples, histogram of uncertainty measures
+* Adjustable grid dimensions


### PR DESCRIPTION
@cooperlab I found some typos while I was going through the code so I fixed them. Also converted `contract.txt` to `contract.md` so it can be viewed easily directly from github.
