### PR TITLE
Fixed the corruption in al_server

### DIFF
--- a/al_server/src/learner.h
+++ b/al_server/src/learner.h
@@ -84,10 +84,12 @@ protected:
 	vector<int>	m_curSet;
 	vector<float> m_curScores;
 
-	//set<int>	m_ignoreSet;	// Contains the dataset index of objects to ignore
+	//set<int> m_ignoreSet; // Contains the dataset index of objects to ignore
 	vector<int> m_ignoreIdx;
 	vector<int>	m_ignoreId;
-	vector<int>	m_ignoreIter;
+	vector<int> m_ignoreLabel;
+	vector<int> m_ignoreIter;
+	vector<string> m_ignoreSlide;
 
 	// Training set info
 	//
@@ -155,6 +157,8 @@ protected:
 
 	bool	Review(const int sock, json_t *obj);
 	bool	SaveReview(const int sock, json_t *obj);
+
+	bool	RemoveIgnored(void);
 
 	bool	RestoreSessionData(MData &trainingSet);
 };


### PR DESCRIPTION
The corruption of the dataset was caused when resizing and moving m_samples. This was almost same with the case of Picker. So, I modified two files: learner.cpp and learner.h. Now, in review, there is no resizing or moving m_samples. Instead, the value of the label will be changed when the user moves the label value to another. In addition, a set of vectors will be used for the values which will be ignored.   