### PR TITLE
Update generating whole slide label via command-line tool

### DIFF
--- a/web_app/reports.html
+++ b/web_app/reports.html
@@ -149,7 +149,7 @@
 				</div>
 
 				<div class="col-sm-4 col-md-4 col-lg-4">
-					<h3>Region labeled</h3>
+					<h3>Training set</h3>
 				</div>
 			</div>
 
@@ -193,6 +193,19 @@
 				</div>
 
 				<div class="col-sm-4 col-md-4 col-lg-4">
+					<form role="form" id="trainingset_form" method="POST" action="php/downloadTrainSet.php">
+						<div class="form-group">
+							<label for="downloadsetSel">Training Set</label>
+							<select class="form-control" id="downloadsetSel" name="downloadset">
+							</select>
+						</div>
+
+						<button type="submit" name="submit-file" class="btn btn-default" value="submitted">Download</button>
+					</form>
+
+				</div>
+
+				<!-- <div class="col-sm-4 col-md-4 col-lg-4">
 					<form role="form" id="label_form" method="POST" action="php/label.php">
 						<div class="form-group">
 							<label for="datasetLabelSel">Dataset</label>
@@ -238,11 +251,10 @@
 						<button id="genLabel" type="submit" name="submit-genLabel" class="btn btn-default" value="mask" >Mask</button>
 					</form>
 
-
-				</div>
+				</div> -->
 			</div>
 		</br>
-			<div class="row">
+			<!-- <div class="row">
 				<div class="col-sm-4 col-md-4 col-lg-4">
 					<h3>Training set</h3>
 				</div>
@@ -274,7 +286,7 @@
 
 					<div class="col-sm-4 col-md-4 col-lg-4">
 					</div>
-			</div>
+			</div> -->
 
 		</div>
 


### PR DESCRIPTION
This pull request includes generating a label image for whole slide image. Given a classifier and a slide name of a dataset, a label image (.tif) and a data file (.H5) for the slide can be generated by a command-line tool. The label image contains label numbers for each superpixel and the data file contains the label numbers and the predict probabilities for the superpixels so that the users can find the predict probability for each superpixel using the label numbers.  

In addition to this update, a tool for extracting specific regions on Report tab is removed because the command-line tool provides the while slide region.