### PR TITLE
Fixed training dataset information updating issue

### DIFF
--- a/web_app/index.html
+++ b/web_app/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 
 <!--
-	Copyright (c) 2014-2017, Emory University
+	Copyright (c) 2014-2018, Emory University
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without modification, are

--- a/web_app/index_home.html
+++ b/web_app/index_home.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 
 <!--
-	Copyright (c) 2014-2017, Emory University
+	Copyright (c) 2014-2018, Emory University
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without modification, are
@@ -154,9 +154,6 @@
 								<br/>
 								<span><strong>Count:</strong></span>
 								<span id="reloadNegCount">0</span>
-								<br/>
-								<span><strong>Iterations:</strong></span>
-								<span id="reloadIter">0</span>
 							</div>
 						</div>
 

--- a/web_app/js/app_main.js
+++ b/web_app/js/app_main.js
@@ -180,13 +180,6 @@ function updateTrainingSet() {
 
 	var trainSet = reloadTrainSetSel.options[reloadTrainSetSel.selectedIndex].label;
 
-	// initialize training set infomation before updating
-	document.getElementById('reloadNeg').innerHTML = "";
-	document.getElementById('reloadPos').innerHTML = "";
-	// document.getElementById('reloadIter').innerHTML = data.iterations;
-	document.getElementById('reloadNegCount').innerHTML = "";
-	document.getElementById('reloadPosCount').innerHTML = "";
-
 	updateTrainingsetInfo(trainSet);
 }
 
@@ -195,6 +188,13 @@ function updateTrainingSet() {
 
 
 function updateTrainingsetInfo(trainSet) {
+
+	// initialize training set infomation before updating
+	document.getElementById('reloadNeg').innerHTML = "";
+	document.getElementById('reloadPos').innerHTML = "";
+	// document.getElementById('reloadIter').innerHTML = data.iterations;
+	document.getElementById('reloadNegCount').innerHTML = "";
+	document.getElementById('reloadPosCount').innerHTML = "";
 
 	$.ajax({
 		type: "POST",

--- a/web_app/js/app_main.js
+++ b/web_app/js/app_main.js
@@ -1,5 +1,5 @@
 //
-//	Copyright (c) 2014-2017, Emory University
+//	Copyright (c) 2014-2018, Emory University
 //	All rights reserved.
 //
 //	Redistribution and use in source and binary forms, with or without modification, are
@@ -180,6 +180,13 @@ function updateTrainingSet() {
 
 	var trainSet = reloadTrainSetSel.options[reloadTrainSetSel.selectedIndex].label;
 
+	// initialize training set infomation before updating
+	document.getElementById('reloadNeg').innerHTML = "";
+	document.getElementById('reloadPos').innerHTML = "";
+	// document.getElementById('reloadIter').innerHTML = data.iterations;
+	document.getElementById('reloadNegCount').innerHTML = "";
+	document.getElementById('reloadPosCount').innerHTML = "";
+
 	updateTrainingsetInfo(trainSet);
 }
 
@@ -198,7 +205,7 @@ function updateTrainingsetInfo(trainSet) {
 
 			document.getElementById('reloadNeg').innerHTML = data.labels[0];
 			document.getElementById('reloadPos').innerHTML = data.labels[1];
-			document.getElementById('reloadIter').innerHTML = data.iterations;
+			// document.getElementById('reloadIter').innerHTML = data.iterations;
 			document.getElementById('reloadNegCount').innerHTML = data.counts[0];
 			document.getElementById('reloadPosCount').innerHTML = data.counts[1];
 		}


### PR DESCRIPTION
Fixed an issue that any training dataset information is not updated when we change the training set combo box.

In addition, because the number of iterations may be meaningful when the users only use "Instance" section not "Heatmap" section, the users who use both "instance and Heatmap" section may be confused about the number of iterations. Thus, the iteration information is removed on the main page. Instead, the users can confirm the iteration information on the instance section whenever they reload their classifier.